### PR TITLE
#9 Remove dependencies

### DIFF
--- a/packs/anti_grief/AntiCreeperGrief/packs/BP/manifest.json
+++ b/packs/anti_grief/AntiCreeperGrief/packs/BP/manifest.json
@@ -15,10 +15,6 @@
     }
   ],
   "dependencies": [
-    {
-      "uuid": "c7e4c3cb-bf32-42f1-8d0d-48ec3a617776",
-      "version": [1, 0, 0]
-    }
   ],
   "metadata": {
     "authors": ["Vanilla Tweaks", "Bedrock Tweaks", "SquatchHunter"]

--- a/packs/anti_grief/AntiCreeperGrief/packs/RP/manifest.json
+++ b/packs/anti_grief/AntiCreeperGrief/packs/RP/manifest.json
@@ -16,10 +16,6 @@
     }
   ],
   "dependencies": [
-    {
-      "uuid": "8a3474e1-d8de-4a4c-b460-ac0345ed567c",
-      "version": [1, 0, 0]
-    }
   ],
   "metadata": {
     "authors": ["Vanilla Tweaks", "Bedrock Tweaks", "SquatchHunter"]


### PR DESCRIPTION
This should resolve the issue with missing dependencies when creating an Anti-Creeper Griefing pack. However, it is more of a short- than a long-term fix. Long-term, I would recommend removing cross-dependencies from the manifests.json as part of the pack creation process.

I don't have time to dig into that at the moment, but will take a look in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused dependencies from add-on configuration files to optimize load requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->